### PR TITLE
feat: ✨ 实现群聊页面静态内容

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ coverage
 *.tsbuildinfo
 
 .vite
+
+.env*

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "mock": "vite --mode mock --host",
+    "dev": "vite --mode development --host",
+    "build": "vite build --host",
     "preview": "vite preview",
     "format": "prettier --write src/"
   },

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -28,7 +28,7 @@ export default defineComponent({
     <div class="transition-all duration-200 ease-in-out overflow-hidden" :style="displaySideMenu ? 'width: 20rem' : 'width: 0'">
       <div class="w-80 h-[calc(100vh-4rem)] overflow-auto border-r border-surface-200 dark:border-surface-700 shadow-xs">
         <template v-for="item in groupList">
-          <RouterLink :to="'/home/groups/' + item.group_id ">
+          <router-link :to="'/home/groups/' + item.group_id ">
             <Card class="dark:bg-surface-900! mx-1 my-2 hover:bg-surface-50! dark:hover:bg-surface-800!">
               <template #title>
                 <div class="flex items-center gap-5 h-12 pt-1">
@@ -53,7 +53,7 @@ export default defineComponent({
                 </div>
               </template>
             </Card>
-          </RouterLink>
+          </router-link>
         </template>
       </div>
     </div>

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -1,0 +1,66 @@
+<script>
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'SideMenu',
+  props: {
+    groupList: Array,
+  },
+  data() {
+    return {
+      displaySideMenu: true,
+    }
+  },
+  methods: {
+    toggleSideMenu() {
+      this.displaySideMenu = !this.displaySideMenu
+    }
+  }
+})
+</script>
+
+<template>
+  <div class="flex">
+    <div class="flex-col h-[calc(100vh-4rem)] w-12 p-1.5 border-r border-surface-200 dark:border-surface-700 shadow-xs">
+      <Button icon="pi pi-align-justify" severity="secondary" size="small" class="my-2" @click="toggleSideMenu()"></Button>
+      <Button icon="pi pi-search" severity="secondary" size="small" class="my-2" @click=""></Button>
+    </div>
+    <div class="transition-all duration-200 ease-in-out overflow-hidden" :style="displaySideMenu ? 'width: 20rem' : 'width: 0'">
+      <div class="w-80 h-[calc(100vh-4rem)] overflow-auto border-r border-surface-200 dark:border-surface-700 shadow-xs">
+        <template v-for="item in groupList">
+          <RouterLink :to="'/home/groups/' + item.group_id ">
+            <Card class="dark:bg-surface-900! mx-1 my-2 hover:bg-surface-50! dark:hover:bg-surface-800!">
+              <template #title>
+                <div class="flex items-center gap-5 h-12 pt-1">
+                  <div>
+                    <Avatar :label="item.group_name[0]" size="xlarge" shape="circle"></Avatar>
+                  </div>
+                  <div class="flex-col gap-2">
+                    <div class="text-lg w-45">
+                      {{ item.group_name.length > 10 ? item.group_name.slice(0,9) + '...' : item.group_name }}
+                    </div>
+                    <div class="flex items-center gap-2 text-sm text-surface-500 dark:text-surface-300 mt-2.5">
+                      <div class="flex items-center gap-2 mr-3 w-12">
+                        <i class="pi pi-users"></i>
+                        <p>{{ item.speaker_num }}</p>
+                      </div>
+                      <div class="flex items-center gap-2">
+                        <i class="pi pi-calendar"></i>
+                        <p>{{ item.end_time.slice(0,10) }}</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </Card>
+          </RouterLink>
+        </template>
+      </div>
+    </div>
+  </div>
+  <div>
+
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/components/Topbar.vue
+++ b/src/components/Topbar.vue
@@ -7,6 +7,7 @@ export default defineComponent({
   data() {
     return {
       authStore: null,
+      tabStatus: "0",
       userOps: [
         {
           label: () => this.authStore.username,
@@ -44,20 +45,25 @@ export default defineComponent({
     logout() {
       this.authStore.logout()
       this.$router.push('/')
-    }
+      this.tabStatus = "0"
+    },
+    toggleTab(value) {
+      this.tabStatus = value
+    },
   },
   created() {
     this.authStore = useAuthStore()
+    this.tabStatus = this.$route.path === '/home' ? '0' : this.$route.path === '/home/groups' ? '1' : '2'
   },
 })
 </script>
 
 <template>
-  <Menubar class="flex h-16 rounded-none! border-x-0! backdrop-blur-lg! bg-surface-0/80! dark:bg-surface-900/80!">
+  <Menubar class="flex h-16 rounded-none! border-x-0! backdrop-blur-lg! bg-surface-0/75! dark:bg-surface-900/75! shadow-xs">
     <template #start>
       <div class="flex items-center gap-5">
         <div class="flex items-center">
-          <router-link to="/">
+          <router-link :to="authStore.loginStatus ? '/home' : '/'" @click="toggleTab('0')">
             <Avatar image="/src/assets/logo.svg" class="mx-2" size="middle"/>
           </router-link>
           <div class="text-primary font-bold text-xl leading-tight">
@@ -69,9 +75,9 @@ export default defineComponent({
     <template #end>
       <div class="flex items-center gap-5">
         <div v-if="authStore.loginStatus">
-          <Tabs value="0" class="border-0! -mb-0.5! mr-3" style="--p-tabs-tab-border-width: 0; --p-tabs-tablist-background: none">
+          <Tabs :value="tabStatus" class="border-0! -mb-0.5! mr-3" style="--p-tabs-tab-border-width: 0; --p-tabs-tablist-background: none">
             <TabList>
-              <router-link to="/home">
+              <router-link to="/home" @click="toggleTab('0')">
                 <Tab class="mb-0.25!" value="0">
                   <a class="flex items-center gap-2 mt-1" >
                     <i class="pi pi-home" style="font-size: 1.2rem"/>
@@ -79,7 +85,7 @@ export default defineComponent({
                   </a>
                 </Tab>
               </router-link>
-              <router-link to="/home/groups">
+              <router-link to="/home/groups" @click="toggleTab('1')">
                 <Tab class="mb-0.25!" value="1">
                   <a class="flex items-center gap-2 mt-1" >
                     <i class="pi pi-comments" style="font-size: 1.2rem"/>
@@ -87,7 +93,7 @@ export default defineComponent({
                   </a>
                 </Tab>
               </router-link>
-              <router-link to="/home/speakers">
+              <router-link to="/home/speakers" @click="toggleTab('2')">
                 <Tab class="mb-0.25!" value="2">
                   <a class="flex items-center gap-2 mt-1" >
                     <i class="pi pi-users" style="font-size: 1.4rem"/>

--- a/src/components/Topbar.vue
+++ b/src/components/Topbar.vue
@@ -53,7 +53,7 @@ export default defineComponent({
   },
   created() {
     this.authStore = useAuthStore()
-    this.tabStatus = this.$route.path === '/home' ? '0' : this.$route.path === '/home/groups' ? '1' : '2'
+    this.tabStatus = this.$route.path === '/home' ? '0' : this.$route.path.slice(0, 12) === '/home/groups' ? '1' : '2'
   },
 })
 </script>
@@ -62,14 +62,14 @@ export default defineComponent({
   <Menubar class="flex h-16 rounded-none! border-x-0! backdrop-blur-lg! bg-surface-0/75! dark:bg-surface-900/75! shadow-xs">
     <template #start>
       <div class="flex items-center gap-5">
-        <div class="flex items-center">
-          <router-link :to="authStore.loginStatus ? '/home' : '/'" @click="toggleTab('0')">
-            <Avatar image="/src/assets/logo.svg" class="mx-2" size="middle"/>
-          </router-link>
-          <div class="text-primary font-bold text-xl leading-tight">
-            ChatKeeper
+        <router-link :to="authStore.loginStatus ? '/home' : '/'" @click="toggleTab('0')">
+          <div class="flex items-center">
+<!--            <Avatar image="/src/assets/logo.svg" class="mx-2" size="middle"/>-->
+            <div class="text-primary font-bold text-2xl leading-tight mr-1">
+              ChatKeeper
+            </div>
           </div>
-        </div>
+        </router-link>
       </div>
     </template>
     <template #end>

--- a/src/layout/AppLayout.vue
+++ b/src/layout/AppLayout.vue
@@ -1,31 +1,40 @@
 <script>
-import {defineComponent} from 'vue'
-import Topbar from "@/components/Topbar.vue";
-import Footer from "@/components/Footer.vue";
+import { defineComponent } from 'vue'
+import Topbar from '@/components/Topbar.vue'
+import Footer from '@/components/Footer.vue'
 
 export default defineComponent({
-  name: "AppLayout",
-  components: {Footer, Topbar},
+  name: 'AppLayout',
+  components: { Footer, Topbar },
   data() {
     return {
-      visible: true
+      visible: true,
     }
   },
-  methods: {}
+  methods: {
+    handleBeforeUnload(event) {
+      event.preventDefault()
+      event.returnValue = ''
+    },
+  },
+  mounted() {
+    window.addEventListener('beforeunload', this.handleBeforeUnload)
+  },
+  beforeUnmount() {
+    window.removeEventListener('beforeunload', this.handleBeforeUnload)
+  },
 })
 </script>
 
 <template>
   <div class="min-h-screen">
-    <Topbar class="fixed! w-full"></Topbar>
+    <Topbar class="fixed! w-full z-9999"></Topbar>
     <div class="pt-16">
-      <Toast class="mt-16"/>
+      <Toast class="mt-16" />
       <router-view></router-view>
     </div>
   </div>
   <Footer></Footer>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import PrimeVue from 'primevue/config'
 import Aura from '@primeuix/themes/aura'
 import ToastService from 'primevue/toastservice'
 import ConfirmationService from 'primevue/confirmationservice'
+import { definePreset } from '@primeuix/themes'
 
 const app = createApp(App)
 
@@ -19,12 +20,78 @@ const pinia = createPinia()
 pinia.use(piniaPluginPersistedstate)
 app.use(pinia)
 
+const Preset = definePreset(Aura, {
+  semantic: {
+    colorScheme: {
+      light: {
+        secondary: {
+          0: '#ffffff',
+          50: '{sky.50}',
+          100: '{sky.100}',
+          200: '{sky.200}',
+          300: '{sky.300}',
+          400: '{sky.400}',
+          500: '{sky.500}',
+          600: '{sky.600}',
+          700: '{sky.700}',
+          800: '{sky.800}',
+          900: '{sky.900}',
+          950: '{sky.950}'
+        },
+        surface: {
+          0: '#ffffff',
+          50: '{slate.50}',
+          100: '{slate.100}',
+          200: '{slate.200}',
+          300: '{slate.300}',
+          400: '{slate.400}',
+          500: '{slate.500}',
+          600: '{slate.600}',
+          700: '{slate.700}',
+          800: '{slate.800}',
+          900: '{slate.900}',
+          950: '{slate.950}'
+        }
+      },
+      dark: {
+        primary: {
+          50: '{indigo.50}',
+          100: '{indigo.100}',
+          200: '{indigo.200}',
+          300: '{indigo.300}',
+          400: '{indigo.400}',
+          500: '{indigo.500}',
+          600: '{indigo.600}',
+          700: '{indigo.700}',
+          800: '{indigo.800}',
+          900: '{indigo.900}',
+          950: '{indigo.950}'
+        },
+        surface: {
+          0: '#ffffff',
+          50: '{slate.50}',
+          100: '{slate.100}',
+          200: '{slate.200}',
+          300: '{slate.300}',
+          400: '{slate.400}',
+          500: '{slate.500}',
+          600: '{slate.600}',
+          700: '{slate.700}',
+          800: '{slate.800}',
+          900: '{slate.900}',
+          950: '{slate.950}'
+        }
+      }
+    }
+  }
+});
+
 app.use(PrimeVue, {
   theme: {
-    preset: Aura,
+    preset: Preset,
     options: {
       darkModeSelector: '.dark-mode-selector',
-    }
+    },
   }
 })
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,6 +22,12 @@ const router = createRouter({
           path: '/home/groups',
           name: 'groups',
           component: () => import('@/views/GroupsView.vue'),
+          children: [
+            {
+              path: '/home/groups/:group_id',
+              name: 'group-detail'
+            }
+          ]
         },
         {
           path: '/home/speakers',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,7 +25,8 @@ const router = createRouter({
           children: [
             {
               path: '/home/groups/:group_id',
-              name: 'group-detail'
+              name: 'group-detail',
+              component: () => import('@/views/GroupDetailView.vue'),
             }
           ]
         },
@@ -38,6 +39,11 @@ const router = createRouter({
           path: '/login',
           name: 'login',
           component: () => import('@/views/LoginView.vue'),
+        },
+        {
+          path: '/:pathMatch(.*)*',
+          name: 'not-found',
+          component: () => import('@/views/NotFoundView.vue'),
         }
       ],
     },

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+const request = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE,
+  timeout: 10000,
+})
+
+export default request

--- a/src/views/GroupDetailView.vue
+++ b/src/views/GroupDetailView.vue
@@ -1,0 +1,214 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'GroupDetailView',
+  props: {
+    currentGroup: Object,
+  },
+  data() {
+    return {
+      searchKey: "",
+    }
+  },
+  methods: {
+    upload(event) {
+      this.$toast.add({
+        severity: 'info',
+        summary: 'Success',
+        detail: 'File Uploaded',
+        life: 3000
+      });
+    }
+  },
+
+})
+</script>
+
+<template>
+  <div class="lg:flex items-start p-5">
+
+    <div class="lg:w-7/12 w-11/12 flex-col">
+
+      <Card class="dark:bg-surface-900! m-3">
+        <template #title>
+          <div class="flex items-center gap-3 mb-1">
+            <Avatar icon="pi pi-address-book" size="large" shape="circle"></Avatar>
+            <p class="text-2xl">{{ currentGroup.group_name }}</p>
+          </div>
+        </template>
+        <template #content>
+          <div class="flex-col items-center m-2">
+            <div class="flex items-center gap-2 mt-2">
+              <div class="flex items-center gap-2 mr-5">
+                <i class="pi pi-users"></i>
+                <p>成员数量：{{ currentGroup.speaker_num }}</p>
+              </div>
+              <div class="flex items-center gap-2 mr-5">
+                <i class="pi pi-users"></i>
+                <p>聊天记录条数：{{ currentGroup.message_num }}</p>
+              </div>
+            </div>
+            <div class="flex items-center gap-2 mt-2">
+              <div class="flex items-center gap-2">
+                <i class="pi pi-calendar"></i>
+                <p>时间范围：{{ currentGroup.start_time.slice(0,10) }} ~ {{ currentGroup.end_time.slice(0,10) }}</p>
+              </div>
+            </div>
+          </div>
+        </template>
+      </Card>
+
+      <Card class="m-3">
+        <template #title>
+          <div class="flex justify-between">
+            <div class="flex items-center gap-3 mb-1">
+              <Avatar icon="pi pi-user" shape="circle"></Avatar>
+              <p>群聊成员</p>
+            </div>
+            <IconField >
+              <InputIcon class="pi pi-search" />
+              <InputText v-model="searchKey" placeholder="搜索群成员" size="small" />
+            </IconField>
+          </div>
+        </template>
+        <template #content>
+          <div v-for="speaker in currentGroup.speaker_list" class="flex-col">
+            <router-link :to="'/home/speakers/' + speaker.speaker_id" v-if="searchKey === '' || speaker.speaker_name.includes(searchKey)">
+              <Card
+                class="my-2 shadow-none!"
+                :class="speaker.analyzed
+                  ? 'bg-primary-50! hover:bg-primary-100! dark:bg-primary-950! dark:hover:bg-primary-900! text-primary-500! dark:text-primary-300!'
+                  : 'bg-surface-100! hover:bg-surface-200! dark:bg-surface-800! dark:hover:bg-surface-700! text-surface-400! dark:text-surface-400!'"
+              >
+                <template #title>
+                  <div class="flex gap-4 items-center text-lg -m-2">
+                    <Badge
+                      size="xlarge"
+                      class="min-w-5/12! mr-2"
+                      :class="speaker.analyzed
+                        ? ''
+                        : 'bg-surface-400! dark:bg-surface-400!'"
+                    >
+                      <p>{{ speaker.speaker_name }}</p>
+                    </Badge>
+                    <div class="flex gap-2 items-center">
+                      <i class="pi pi-tag"></i>
+                      <p size="large" class=" font-bold" >
+                        {{ speaker.speaker_qq }}
+                      </p>
+                    </div>
+
+                  </div>
+                </template>
+                <template #content>
+                  <div class="-m-2 mt-3">
+                    <div class="flex items-center gap-3 mr-2">
+                      <i class="pi pi-send"></i>
+                      <MeterGroup
+                        :value="[{
+                          label: '',
+                          value: (speaker.speaker_msg_freq / currentGroup.max_msg_freq * 100),
+                          color: speaker.analyzed ? 'var(--p-primary-color)' : 'var(--p-surface-400)'
+                        }]"
+                        class="w-9/12"
+                        :pt="{
+                          labelList: { class: 'hidden!' },
+                        }"
+                      >
+                      </MeterGroup>
+                      <p class="font-bold text-sm">{{ speaker.speaker_msg_freq }}</p>
+                    </div>
+                  </div>
+                </template>
+              </Card>
+            </router-link>
+          </div>
+        </template>
+      </Card>
+
+    </div>
+
+    <div class="lg:w-5/12 w-11/12 flex-col">
+
+      <Card class="dark:bg-surface-900! m-3">
+        <template #title>
+          <div class="flex items-center gap-3 mb-1">
+            <Avatar icon="pi pi-lightbulb" shape="circle"></Avatar>
+            <p>发现群成员</p>
+          </div>
+        </template>
+        <template #content>
+          <div class="text-surface-500! dark:text-surface-300! mt-2">
+            在搜索框中输入你的“兴趣关键词”，我们将为你发现你可能感兴趣的群聊成员，快来试试吧！
+          </div>
+          <div class="flex items-start justify-between mt-3">
+            <InputText v-model="value" placeholder="兴趣关键词" class=" w-[calc(100%-100px)]"/>
+            <Button @click="">
+              <i class="pi pi-lightbulb"></i>
+              <p>发现</p>
+            </Button>
+          </div>
+        </template>
+      </Card>
+
+      <Card class="dark:bg-surface-900! m-3">
+        <template #title>
+          <div class="flex items-center gap-3 mb-1">
+            <Avatar icon="pi pi-upload" shape="circle"></Avatar>
+            <p>上传聊天记录</p>
+          </div>
+        </template>
+        <template #content>
+          <div class="flex items-start mt-2">
+            <FileUpload
+              choose-label="选择"
+              upload-label="上传"
+              cancel-label="取消"
+              name="demo[]"
+              url="/api/upload"
+              @upload="upload($event)"
+              accept=".txt"
+              :maxFileSize="1000000"
+              :pt="{
+                root: { class: 'w-full!' },
+                content: { class: 'min-h-15' },
+                pcChooseButton: { root: { class: 'p-button-outlined p-button-info' } },
+                pcUploadButton: { root: { class: 'p-button-outlined p-button-success' } },
+                pcCancelButton: { root: { class: 'p-button-outlined p-button-danger' } },
+                fileThumbnail: { class: 'hidden!' },
+                pcFileBadge: { root: { variant: 'outlined' } },
+              }"
+            >
+              <template #empty>
+                <p class="text-surface-500! dark:text-surface-300!">请点击按钮或者将文件拖动到这里</p>
+              </template>
+            </FileUpload>
+          </div>
+        </template>
+      </Card>
+
+      <Card class="dark:bg-surface-900! m-3">
+        <template #title>
+          <div class="flex items-center gap-3 mb-1">
+            <Avatar icon="pi pi-sliders-h" shape="circle"></Avatar>
+            <p>群聊设置</p>
+          </div>
+        </template>
+        <template #content>
+          <div class="flex-col items-center">
+            <div class="flex items-center gap-4 mt-2">
+              <Button label="设置群聊" severity="secondary" variant="outlined" />
+              <Button label=" 删除群聊" severity="danger" variant="outlined" />
+            </div>
+          </div>
+        </template>
+      </Card>
+
+    </div>
+
+  </div>
+
+</template>
+
+<style scoped></style>

--- a/src/views/GroupsView.vue
+++ b/src/views/GroupsView.vue
@@ -3,15 +3,17 @@ import { defineComponent } from 'vue'
 import { useAuthStore } from '@/store/auth.js'
 import SideMenu from '@/components/SideMenu.vue'
 import request from '@/utils/request.js'
+import GroupDetailView from '@/views/GroupDetailView.vue'
 
 export default defineComponent({
   name: 'GroupsView',
-  components: { SideMenu },
+  components: { GroupDetailView, SideMenu },
   data() {
     return {
       authStore: null,
       groupNum: 0,
       groupList: [],
+      currentGroup: null,
     }
   },
   methods: {
@@ -37,14 +39,28 @@ export default defineComponent({
     this.authStore = useAuthStore()
     this.getGroups()
   },
+  watch: {
+    '$route'(to, from) {
+      console.log(to.params.group_id)
+      this.currentGroup = this.groupList.find(group => group.group_id === to.params.group_id)
+      if (!this.currentGroup) {
+        this.$router.push('/home/groups')
+        console.log('not found')
+      }
+      this.currentGroup.speaker_list.sort((a, b) => b.speaker_msg_freq - a.speaker_msg_freq)
+      this.currentGroup['max_msg_freq'] = this.currentGroup.speaker_list[0].speaker_msg_freq
+    }
+  }
 })
 </script>
 
 <template>
-  <div class="flex gap-5">
-        <SideMenu :group-list="groupList" class="h-[calc(100vh-4rem)]"></SideMenu>
-    <div class="p-2">
-
+  <div class="flex items-start">
+    <div class="flex-shrink-0 sticky top-16">
+      <SideMenu :group-list="groupList" class="h-[calc(100vh-4rem)]"></SideMenu>
+    </div>
+    <div class="flex-grow min-h-[calc(100vh-4rem)] bg-surface-50 dark:bg-surface-950">
+      <router-view :current-group="currentGroup"></router-view>
     </div>
   </div>
 </template>

--- a/src/views/GroupsView.vue
+++ b/src/views/GroupsView.vue
@@ -1,15 +1,52 @@
 <script>
 import { defineComponent } from 'vue'
+import { useAuthStore } from '@/store/auth.js'
+import SideMenu from '@/components/SideMenu.vue'
+import request from '@/utils/request.js'
 
 export default defineComponent({
-  name: 'GroupsView'
+  name: 'GroupsView',
+  components: { SideMenu },
+  data() {
+    return {
+      authStore: null,
+      groupNum: 0,
+      groupList: [],
+    }
+  },
+  methods: {
+    getGroups() {
+      request.get('/data/group/list', {
+        user_id: this.authStore.userId,
+        token: this.authStore.token,
+      })
+      .then((response) => {
+        console.log(response)
+        if (response.data.code === 200) {
+          this.groupNum = response.data.data.group_num
+          this.groupList = response.data.data.group_list
+          console.log(response.data.msg)
+        }
+      })
+      .catch((error) => {
+        console.log(error)
+      })
+    }
+  },
+  created() {
+    this.authStore = useAuthStore()
+    this.getGroups()
+  },
 })
 </script>
 
 <template>
+  <div class="flex gap-5">
+        <SideMenu :group-list="groupList" class="h-[calc(100vh-4rem)]"></SideMenu>
+    <div class="p-2">
 
+    </div>
+  </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,6 +1,6 @@
 <script>
 import {defineComponent} from 'vue'
-import axios from 'axios'
+import request from '@/utils/request.js'
 import {useAuthStore} from "@/store/auth.js";
 
 export default defineComponent({
@@ -14,7 +14,7 @@ export default defineComponent({
   },
   methods: {
     login() {
-      axios.post('/mock/auth/login', {
+      request.post('/auth/login', {
         username: this.username,
         password: this.password,
       })

--- a/src/views/NotFoundView.vue
+++ b/src/views/NotFoundView.vue
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'NotFoundView'
+})
+</script>
+
+<template>
+  <div class="flex justify-center items-center h-[calc(100vh-4rem)] w-full">
+    <div class="flex-col items-center w-full">
+      <div class="flex justify-center m-5">
+        <div class="font-bold text-9xl text-primary-500">404</div>
+      </div>
+      <div class="flex justify-center m-5">
+        <div class="font-bold text-5xl text-primary-500">哎呦！你的网页不见啦~</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,22 +24,4 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
-  base: '/',
-  // 设置反向代理实现跨域访问服务端
-  server: {
-    proxy: {
-      // mock服务器
-      '/mock': {
-        target: 'http://127.0.0.1:4523/m1/6398604-6095377-default',
-        changeOrigin: true,
-        rewrite: path => path.replace(/^\/mock/, '')
-      },
-      // 开发服务器
-      '/dev': {
-        target: 'http://127.0.0.1:5000',
-        changeOrigin: true,
-        rewrite: path => path.replace(/^\/dev/, '')
-      }
-    }
-  },
 })


### PR DESCRIPTION
- 在`GroupDetailView`中布局群聊基本信息显示、群成员显示、以及群文件上传等模块的静态内容
- 调整`SideMenu`的布局模式，实现滚动粘滞
- 添加`NotFoundView`视图
- 更新路由
- 修复其他问题

——黄润轩